### PR TITLE
Remove Revue link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,10 +21,6 @@ const socials = [
     label: 'Github',
   },
   {
-    url: 'https://www.getrevue.co/profile/generalmagic',
-    label: 'Revue',
-  },
-  {
     url: 'https://www.linkedin.com/company/generalmagicio/',
     label: 'Linkedin',
   },


### PR DESCRIPTION
Revue has been [discontinued](https://help.twitter.com/en/using-twitter/revue)